### PR TITLE
Cloud URLs Regex subdomains should contain - or _

### DIFF
--- a/src/main/java/burp/utils/Constants.java
+++ b/src/main/java/burp/utils/Constants.java
@@ -19,7 +19,7 @@ public class Constants {
     public static final String WHITE_SPACES = "(\\s*)";
     public static final String REGEX_QUOTES = "['\"`]";
 
-    public static final Pattern CLOUD_URLS_REGEX = Pattern.compile("([\\w]+[.]){1,10}" + // get up to 10 subdomain levels
+    public static final Pattern CLOUD_URLS_REGEX = Pattern.compile("([\\w-_]+[.]){1,10}" + // get up to 10 subdomain levels
                     "(s3.amazonaws.com|rds.amazonaws.com|cache.amazonaws.com|" + // AWS
                     "blob.core.windows.net|onedrive.live.com|1drv.com|" + // Azure
                     "storage.googleapis.com|storage.cloud.google.com|storage-download.googleapis.com|content-storage-upload.googleapis.com|content-storage-download.googleapis.com|" + // Google


### PR DESCRIPTION
In Cloud URLs regex currently - or _ is not allowed this could give lots of false positives since when you have:

test-dev.s3.amazonaws.com

Currently the regex just gets the: dev.s3.amazon.com part of the domain which might belong to other company or does not exists.
Subdomains could contain - or _ characters in real life. For example I have tested on amazonaws with amass and there are lots of results subdomains containing "-" e.g.:

[CommonCrawl]     cbdigitaletl-prod.s3.amazonaws.com 54.231.141.1
[Maltiverse]      unicommerce-channel-shippinglabels.s3.amazonaws.com 52.219.40.132
[Maltiverse]      cbc-drupal-assets.s3.amazonaws.com 52.92.163.137
[CommonCrawl]     bac-downloads.s3.amazonaws.com 54.231.141.1
[CommonCrawl]     bluezonesproject-enterprise.s3.amazonaws.com 54.231.141.1
[Maltiverse]      windeln-assets.s3.amazonaws.com 52.219.170.47